### PR TITLE
Minor spelling fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CARAVAN is a project whose aim is to move the creation of large-sample hydrological (LSH) datasets to the cloud. LSH datasets include data from large samples (tens to thousands) of catchments and enable researchers to go beyond individual case studies and derive robust conclusions on hydrological processes and models. 
 
-CARVAN should enable users to create LSH datasets similar to the [CAMELS](https://ncar.github.io/hydrology/datasets/CAMELS_timeseries) (Catchment Attributes and MEteorology for Large-sample Studies) dataset on the cloud, eventually leading to a suite of CAMELS, aka a [CARVAN](https://en.wikipedia.org/wiki/Camel_train).
+CARAVAN should enable users to create LSH datasets similar to the [CAMELS](https://ncar.github.io/hydrology/datasets/CAMELS_timeseries) (Catchment Attributes and MEteorology for Large-sample Studies) dataset on the cloud, eventually leading to a suite of CAMELS, aka a [CARAVAN](https://en.wikipedia.org/wiki/Camel_train).
 
 # Motivation
 


### PR DESCRIPTION
"CARVAN" -> "CARAVAN"